### PR TITLE
use middleware.Recover()

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
-	"github.com/labstack/echo"
-	"github.com/takutakahashi/k8s-docker-image-builder/routes"
 	"log"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+	"github.com/takutakahashi/k8s-docker-image-builder/routes"
 )
 
 func main() {
-	log.Fatal(routes.Route(echo.New()).Start(":8080"))
+	e := echo.New()
+	e.Use(middleware.Recover())
+	log.Fatal(routes.Route(e).Start(":8080"))
 }
 
 // check https://echo.labstack.com/cookbook/streaming-response


### PR DESCRIPTION
We're using `panic` here so we should use middleware.Recover() to handle this.
https://github.com/takutakahashi/k8s-docker-image-builder/blob/99c6df8df346b49bd382f6080eb0a41863ef17bc/routes/routes.go#L13